### PR TITLE
Add support for all recipes tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,4 @@
 
 ### TODO
 
-- Combine / clean all ingredients to make one master list
-- Allow all indexes to be viewed at the same time
+- Clean all ingredients to make one master list

--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,22 @@ ReactGA.initialize('UA-103648191-1');
 
 const history = createHistory();
 
+//Add the name of the book so that the tooltips are more useful on the 'all' screen
+const addBookName = (arr, name) => {
+  return arr.map(value => (Object.assign(value, {book:name})));
+}
+const allRecipes = [
+  ...addBookName(pdtRecipes, 'PDT'),
+  ...addBookName(deathAndCoRecipes, 'Death & Co'),
+  ...addBookName(smugglersCoveRecipes, 'Smuggler\'s Cove'),
+  ...addBookName(vsAndFcRecipes, 'Vintage Spirits and Forgotten')
+];
+
 const indexes = map([{
+  name: 'All',
+  link: '/all',
+  recipes: allRecipes
+}, {
   name: 'PDT',
   link: '/pdt',
   recipes: pdtRecipes,
@@ -79,7 +94,7 @@ const App = ({ toggle, isOpen, ...props }) => {
                   <CocktailIndex name={i.name} recipes={i.recipes} ingredients={i.ingredients} saveKey={`selected`} />
                 )} />
             ))}
-            <Route render={() => <Redirect to="/pdt" />}></Route>
+            <Route render={() => <Redirect to="/all" />}></Route>
           </Switch>
           <p className="text-muted mt-3 text-center">Thanks to ThePaternalDrunk, el_joker1 & rebeldragonlol for the index spreadsheets</p>
         </div>

--- a/src/CocktailIndex.js
+++ b/src/CocktailIndex.js
@@ -80,8 +80,9 @@ const enhance = compose(
       return { dirty: false };
     }
   }),
-  withPropsOnChange(['selected'], ({ selected, recipes }) => {
+  withPropsOnChange(['selected'], ({ selected, recipes, name }) => {
     let nameIndex = 0;
+    let sectionName = name;
     const list = chain(recipes)
       .sortBy('ingredient')
       .groupBy('name')
@@ -98,6 +99,7 @@ const enhance = compose(
           name: name,
           index: nameIndex++,
           page: b[0].page,
+          book: sectionName === 'All' ? b[0].book : null,
           numMissing: missing.length,
           missing,
           raw: b,

--- a/src/CocktailRow.js
+++ b/src/CocktailRow.js
@@ -12,7 +12,7 @@ export const CocktailRow = ({ item, toggle, isOpen, ...props }) => {
       <td>
         <div>
           {isOpen && <Popover placement="right" isOpen={isOpen} toggle={toggle} target={`cocktail_${item.index}`}>
-            <PopoverTitle>{item.name}{!!item.page && ` (p${item.page})`}</PopoverTitle>
+            <PopoverTitle>{item.name}{!!item.page && ` (${item.book ? `${item.book} ` : ''}p${item.page})`}</PopoverTitle>
             <PopoverContent className="small">
               <ul className="list-unstyled">
               {item.raw.map(i => (


### PR DESCRIPTION
Hi there - 

I love the app and I saw that you had some things to tackle in your todo list, so I figured I'd submit a PR to knock one off the list.

This PR changes the main page to '/all' and creates a master index complete with the book title (so that the tool tip shows the name of the book not just a page number on the 'all' list). Let me know if you want something changed. 

Cheers  :tumbler_glass: